### PR TITLE
Forked JArrayHelper getValue method due to minor change in Joomla 3.4 AP...

### DIFF
--- a/libraries/shmanic/factory.php
+++ b/libraries/shmanic/factory.php
@@ -147,7 +147,7 @@ abstract class SHFactory
 	{
 		if (is_array($user))
 		{
-			$username = strtolower(JArrayHelper::getValue($user, 'username', null, 'string'));
+			$username = strtolower(SHUtilArrayhelper::getValue($user, 'username', null, 'string'));
 			$credentials = $user;
 		}
 		else
@@ -222,7 +222,7 @@ abstract class SHFactory
 		else
 		{
 			// Update credentials if required
-			if ($password = JArrayHelper::getValue($user, 'password', false))
+			if ($password = SHUtilArrayhelper::getValue($user, 'password', false))
 			{
 				self::$adapters[$username]->updateCredential($password, $options);
 			}
@@ -242,7 +242,7 @@ abstract class SHFactory
 	 */
 	public static function getCrypt($options = array())
 	{
-		$source = strtolower(JArrayHelper::getValue($options, 'source', 'jconfig', 'string'));
+		$source = strtolower(SHUtilArrayhelper::getValue($options, 'source', 'jconfig', 'string'));
 
 		if ($source === 'jconfig')
 		{
@@ -262,7 +262,7 @@ abstract class SHFactory
 		}
 		elseif ($source === 'file')
 		{
-			$file = JArrayHelper::getValue($options, 'file', '', 'string');
+			$file = SHUtilArrayhelper::getValue($options, 'file', '', 'string');
 
 			if (file_exists($file))
 			{
@@ -273,8 +273,8 @@ abstract class SHFactory
 		$crypt = new JCrypt;
 
 		// Create some default options
-		$type = JArrayHelper::getValue($options, 'type', 'simple', 'string');
-		$key = JArrayHelper::getValue($options, 'key', 'DEFAULTKEY', 'string');
+		$type = SHUtilArrayhelper::getValue($options, 'type', 'simple', 'string');
+		$key = SHUtilArrayhelper::getValue($options, 'key', 'DEFAULTKEY', 'string');
 
 		$crypt->setKey(
 			new JCryptKey(

--- a/libraries/shmanic/ldap/event/bouncer.php
+++ b/libraries/shmanic/ldap/event/bouncer.php
@@ -452,7 +452,7 @@ class SHLdapEventBouncer extends JEvent
 	public function onUserLoginFailure($response)
 	{
 		// Check if the attempted login was an Ldap user, if so then fire the event
-		if ($username = JArrayHelper::getValue($response, 'username', false, 'string'))
+		if ($username = SHUtilArrayhelper::getValue($response, 'username', false, 'string'))
 		{
 			// Check if the user exists in the J! database
 			if ($id = JUserHelper::getUserId($username))

--- a/libraries/shmanic/ldap/ldap.php
+++ b/libraries/shmanic/ldap/ldap.php
@@ -318,9 +318,9 @@ class SHLdap
 		$registry = is_null($registry) ? SHFactory::getConfig() : $registry;
 
 		// Get the optional authentication/authorisation options
-		$authenticate = JArrayHelper::getValue($authorised, 'authenticate', self::AUTH_NONE);
-		$username = JArrayHelper::getValue($authorised, 'username', null);
-		$password = JArrayHelper::getValue($authorised, 'password', null);
+		$authenticate = SHUtilArrayhelper::getValue($authorised, 'authenticate', self::AUTH_NONE);
+		$username = SHUtilArrayhelper::getValue($authorised, 'username', null);
+		$password = SHUtilArrayhelper::getValue($authorised, 'password', null);
 
 		// Get all the Ldap configs that are enabled and available
 		$configs = SHLdapHelper::getConfig($id, $registry);

--- a/libraries/shmanic/ldap/result.php
+++ b/libraries/shmanic/ldap/result.php
@@ -95,7 +95,7 @@ final class SHLdapResult
 	 */
 	public function getEntry($entry, $default = false)
 	{
-		return JArrayHelper::getValue($this->_results, $entry, $default);
+		return SHUtilArrayhelper::getValue($this->_results, $entry, $default);
 	}
 
 	/**
@@ -131,7 +131,7 @@ final class SHLdapResult
 			return $default;
 		}
 
-		$values = JArrayHelper::getValue($getEntry, $attribute, $default);
+		$values = SHUtilArrayhelper::getValue($getEntry, $attribute, $default);
 
 		return $values;
 	}
@@ -220,7 +220,7 @@ final class SHLdapResult
 	{
 		$array = array_keys($this->getEntry($entry));
 
-		return JArrayHelper::getValue(
+		return SHUtilArrayhelper::getValue(
 			$array, $index, $default
 		);
 	}
@@ -284,6 +284,6 @@ final class SHLdapResult
 			return $default;
 		}
 
-		return JArrayHelper::getValue($getAttribute, $value, $default);
+		return SHUtilArrayhelper::getValue($getAttribute, $value, $default);
 	}
 }

--- a/libraries/shmanic/lib_shmanic.xml
+++ b/libraries/shmanic/lib_shmanic.xml
@@ -56,6 +56,7 @@
 		<filename>user/adapters/ldap.php</filename>
 		<filename>user/helper.php</filename>
 		<filename>util/ip.php</filename>
+		<filename>util/arrayhelper.php</filename>
 		<filename>factory.php</filename>
 		<filename>import.php</filename>
 		<filename>loader.php</filename>

--- a/libraries/shmanic/user/adapters/ldap.php
+++ b/libraries/shmanic/user/adapters/ldap.php
@@ -128,8 +128,8 @@ class SHUserAdaptersLdap implements SHUserAdapter
 	 */
 	public function __construct(array $credentials, $config = null, array $options = array())
 	{
-		$this->username = JArrayHelper::getValue($credentials, 'username');
-		$this->password = JArrayHelper::getValue($credentials, 'password');
+		$this->username = SHUtilArrayhelper::getValue($credentials, 'username');
+		$this->password = SHUtilArrayhelper::getValue($credentials, 'password');
 
 		if (isset($credentials['domain']))
 		{
@@ -150,9 +150,9 @@ class SHUserAdaptersLdap implements SHUserAdapter
 		}
 
 		// If the user is new then the user creation script needs to provide a dn for the new object
-		if ($this->isNew = JArrayHelper::getValue($options, 'isNew', false, 'boolean'))
+		if ($this->isNew = SHUtilArrayhelper::getValue($options, 'isNew', false, 'boolean'))
 		{
-			$this->_dn = JArrayHelper::getValue($credentials, 'dn');
+			$this->_dn = SHUtilArrayhelper::getValue($credentials, 'dn');
 
 			/*
 			 * If the Ldap parameter override has been set then directly instantiate
@@ -807,7 +807,7 @@ class SHUserAdaptersLdap implements SHUserAdapter
 		}
 
 		// If the user write is enabled then we should just try to authenticate now
-		if ($userWrite = JArrayHelper::getValue($options, 'userWrite', false, 'boolean'))
+		if ($userWrite = SHUtilArrayhelper::getValue($options, 'userWrite', false, 'boolean'))
 		{
 			$this->getId(true);
 		}

--- a/libraries/shmanic/util/arrayhelper.php
+++ b/libraries/shmanic/util/arrayhelper.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * PHP Version 5.3
+ *
+ * @package     Shmanic.Libraries
+ * @subpackage  Util
+ * @author      Shaun Maunder <shaun@shmanic.com>
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * A temporary fork of the Joomla 3.3 code to get around the enforced type'd $array
+ *  parameter of getValue().
+ *
+ * @package     Shmanic.Libraries
+ * @subpackage  Util
+ * @since       2.0.3
+ * @deprecated  2.0.3
+ */
+abstract class SHUtilArrayhelper
+{
+	/**
+	 * Utility function to return a value from a named array or a specified default
+	 *
+	 * @param   array   &$array   A named array
+	 * @param   string  $name     The key to search for
+	 * @param   mixed   $default  The default value to give if no key found
+	 * @param   string  $type     Return type for the variable (INT, FLOAT, STRING, WORD, BOOLEAN, ARRAY)
+	 *
+	 * @return  mixed  The value from the source array
+	 *
+	 * @since       2.0.3
+	 * @deprecated  2.0.3
+	 */
+	public static function getValue(&$array, $name, $default = null, $type = '')
+	{
+		$result = null;
+
+		if (isset($array[$name]))
+		{
+			$result = $array[$name];
+		}
+
+		// Handle the default case
+		if (is_null($result))
+		{
+			$result = $default;
+		}
+
+		// Handle the type constraint
+		switch (strtoupper($type))
+		{
+			case 'INT':
+			case 'INTEGER':
+				// Only use the first integer value
+				@preg_match('/-?[0-9]+/', $result, $matches);
+				$result = @(int) $matches[0];
+				break;
+
+			case 'FLOAT':
+			case 'DOUBLE':
+				// Only use the first floating point value
+				@preg_match('/-?[0-9]+(\.[0-9]+)?/', $result, $matches);
+				$result = @(float) $matches[0];
+				break;
+
+			case 'BOOL':
+			case 'BOOLEAN':
+				$result = (bool) $result;
+				break;
+
+			case 'ARRAY':
+				if (!is_array($result))
+				{
+					$result = array($result);
+				}
+				break;
+
+			case 'STRING':
+				$result = (string) $result;
+				break;
+
+			case 'WORD':
+				$result = (string) preg_replace('#\W#', '', $result);
+				break;
+
+			case 'NONE':
+			default:
+				// No casting necessary
+				break;
+		}
+
+		return $result;
+	}
+}

--- a/plugins/authentication/shadapter/shadapter.php
+++ b/plugins/authentication/shadapter/shadapter.php
@@ -79,7 +79,7 @@ class PlgAuthenticationSHAdapter extends JPlugin
 		}
 
 		// Check if a Domain is present which represents a configuration ID
-		if ($domain = JArrayHelper::getValue($options, 'domain', null, 'cmd'))
+		if ($domain = SHUtilArrayhelper::getValue($options, 'domain', null, 'cmd'))
 		{
 			// Valid configuration ID (normally for SSO)
 			$credentials['domain'] = $domain;

--- a/plugins/ldap/creation/creation.php
+++ b/plugins/ldap/creation/creation.php
@@ -88,10 +88,10 @@ class PlgLdapCreation extends JPlugin
 
 			// Populate defaults for the mandatory
 			$mandatory = array(
-				'username' => JArrayHelper::getValue($user, 'username'),
-				'password' => JArrayHelper::getValue($user, 'password_clear'),
-				'email' => JArrayHelper::getValue($user, 'email'),
-				'name' => JArrayHelper::getValue($user, 'name')
+				'username' => SHUtilArrayhelper::getValue($user, 'username'),
+				'password' => SHUtilArrayhelper::getValue($user, 'password_clear'),
+				'email' => SHUtilArrayhelper::getValue($user, 'email'),
+				'name' => SHUtilArrayhelper::getValue($user, 'name')
 			);
 
 			// Include the helper file only if it exists

--- a/plugins/ldap/mapping/mapping.php
+++ b/plugins/ldap/mapping/mapping.php
@@ -440,7 +440,7 @@ class PlgLdapMapping extends JPlugin
 			 */
 			$attribute = $this->lookup_type === self::LOOKUP_FORWARD ? $this->memberof_attribute : $this->member_attribute;
 			$attributes = $adapter->getAttributes($attribute);
-			$userGroups = JArrayHelper::getValue(
+			$userGroups = SHUtilArrayhelper::getValue(
 				$attributes, $attribute
 			);
 
@@ -1055,7 +1055,7 @@ class SHLdapMappingEntry extends JObject
 			 */
 			$explode = SHLdap::explodeDn($dn, 0);
 
-			if (JArrayHelper::getValue($explode, 'count', false))
+			if (SHUtilArrayhelper::getValue($explode, 'count', false))
 			{
 				// Break up the distinguished name into an array and lowercase it
 				$this->rdn = array_map('strToLower', $explode);

--- a/plugins/ldap/password/password.php
+++ b/plugins/ldap/password/password.php
@@ -59,8 +59,8 @@ class PlgLdapPassword extends JPlugin
 		}
 
 		// Get username and password to use for authenticating with Ldap
-		$username 	= JArrayHelper::getValue($user, 'username', false, 'string');
-		$password 	= JArrayHelper::getValue($new, 'password_clear', null, 'string');
+		$username 	= SHUtilArrayhelper::getValue($user, 'username', false, 'string');
+		$password 	= SHUtilArrayhelper::getValue($new, 'password_clear', null, 'string');
 
 		if (!empty($password))
 		{
@@ -80,7 +80,7 @@ class PlgLdapPassword extends JPlugin
 
 				$adapter->setPassword(
 					$password,
-					JArrayHelper::getValue($new, 'current-password', null, 'string'),
+					SHUtilArrayhelper::getValue($new, 'current-password', null, 'string'),
 					$authenticate
 				);
 

--- a/plugins/ldap/profile/profile.php
+++ b/plugins/ldap/profile/profile.php
@@ -364,7 +364,7 @@ class PlgLdapProfile extends JPlugin
 			 */
 			if ($inForm = JFactory::getApplication()->input->get('jform', false, 'array'))
 			{
-				$id = JArrayHelper::getValue($inForm, 'id', 0, 'int');
+				$id = SHUtilArrayhelper::getValue($inForm, 'id', 0, 'int');
 
 				if ($id === 0)
 				{
@@ -475,12 +475,12 @@ class PlgLdapProfile extends JPlugin
 		try
 		{
 			// Get username for adapter
-			$username = JArrayHelper::getValue($user, 'username', false, 'string');
+			$username = SHUtilArrayhelper::getValue($user, 'username', false, 'string');
 
 			if (empty($username))
 			{
 				// The old username isn't present so use new username
-				$username = JArrayHelper::getValue($new, 'username', false, 'string');
+				$username = SHUtilArrayhelper::getValue($new, 'username', false, 'string');
 			}
 
 			// Include the mandatory Joomla fields (fullname and email)

--- a/tests/suites/jmml/ldap/SHLdapTest.php
+++ b/tests/suites/jmml/ldap/SHLdapTest.php
@@ -508,7 +508,7 @@ class SHLdapTest extends PHPUnit_Framework_TestCase
 		// Test Non-random one first
 		$this->assertEquals(
 			$user['dn'],
-			JArrayHelper::getValue($ldap->getUserDnBySearch($user['username']), 0)
+			SHUtilArrayhelper::getValue($ldap->getUserDnBySearch($user['username']), 0)
 		);
 
 		// Loop 50 times to test random users
@@ -519,7 +519,7 @@ class SHLdapTest extends PHPUnit_Framework_TestCase
 
 			$this->assertEquals(
 				$user['dn'],
-				JArrayHelper::getValue($ldap->getUserDnBySearch($user['username']), 0),
+				SHUtilArrayhelper::getValue($ldap->getUserDnBySearch($user['username']), 0),
 				"Failed to get User DN for {$user['dn']}"
 			);
 		}
@@ -538,7 +538,7 @@ class SHLdapTest extends PHPUnit_Framework_TestCase
 
 			$this->assertEquals(
 				$user['dn'],
-				JArrayHelper::getValue($ldap->getUserDnBySearch($user['username']), 0),
+				SHUtilArrayhelper::getValue($ldap->getUserDnBySearch($user['username']), 0),
 				"Failed to get User DN for {$user['dn']}"
 			);
 		}
@@ -556,7 +556,7 @@ class SHLdapTest extends PHPUnit_Framework_TestCase
 		$ldap->connect();
 
 		$user = TestsHelper::getUserCreds();
-		JArrayHelper::getValue($ldap->getUserDnBySearch($user['username']), 0);
+		SHUtilArrayhelper::getValue($ldap->getUserDnBySearch($user['username']), 0);
 	}
 
 	public function testSlapdGetUserDNSearchBaseDnFail()
@@ -571,7 +571,7 @@ class SHLdapTest extends PHPUnit_Framework_TestCase
 		$ldap->connect();
 
 		$user = TestsHelper::getUserCreds();
-		JArrayHelper::getValue($ldap->getUserDnBySearch($user['username']), 0);
+		SHUtilArrayhelper::getValue($ldap->getUserDnBySearch($user['username']), 0);
 	}
 
 	public function testSlapdGetUserDNDirectly()
@@ -583,14 +583,14 @@ class SHLdapTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals(
 			$user['dn'],
-			JArrayHelper::getValue($ldap->getUserDnDirectly($user['username']), 0)
+			SHUtilArrayhelper::getValue($ldap->getUserDnDirectly($user['username']), 0)
 		);
 
 		$user = TestsHelper::getUserCreds('kryten');
 
 		$this->assertEquals(
 			$user['dn'],
-			JArrayHelper::getValue($ldap->getUserDnDirectly($user['username']), 0)
+			SHUtilArrayhelper::getValue($ldap->getUserDnDirectly($user['username']), 0)
 		);
 	}
 

--- a/tests/suites/jmml/user/SHUserAdaptersLdapTest.php
+++ b/tests/suites/jmml/user/SHUserAdaptersLdapTest.php
@@ -399,7 +399,7 @@ class SHUserAdaptersLdapTest extends TestCase
 			// Test the new user
 			$testAdapter = new SHUserAdaptersLdap($user, $ldap);
 			$this->assertEquals($user['dn'], $testAdapter->getId(true));
-			$phone = JArrayHelper::getValue($testAdapter->getAttributes('telephoneNumber'), 'telephoneNumber');
+			$phone = SHUtilArrayhelper::getValue($testAdapter->getAttributes('telephoneNumber'), 'telephoneNumber');
 			$this->assertEquals($user['telephoneNumber'], $phone);
 
 			// Delete the new user


### PR DESCRIPTION
Forked JArrayHelper getValue method due to minor change in Joomla 3.4 I which meant that if first parameter was not an array, fatal error would be thrown.
