### PR TITLE
Permit to configure multiple LDAP attributes name for name/email mapping

### DIFF
--- a/administrator/components/com_shldap/views/host/tmpl/debug.php
+++ b/administrator/components/com_shldap/views/host/tmpl/debug.php
@@ -71,20 +71,28 @@ try
 		echo "<p style=\"{$errorStyle}\">Invalid Map User ID.</p>";
 	}
 
-	if ($fullname = $read->getValue(0, $client->keyName, 0))
+	foreach(explode(',', $client->keyName) as $attr)
 	{
-		echo "Full Name: {$fullname} <br />";
+		if ($fullname = $read->getValue(0, $attr, 0))
+		{
+			echo "Full Name: {$fullname} <br />";
+			break;
+		}
 	}
-	else
+	if (!$fullname)
 	{
 		echo "<p style=\"{$errorStyle}\">Invalid Map Full Name.</p>";
 	}
 
-	if ($email = $read->getValue(0, $client->keyEmail, 0))
+	foreach(explode(',', $client->keyEmail) as $attr)
 	{
-		echo "Email: {$email} <br />";
+		if ($email = $read->getValue(0, $attr, 0))
+		{
+			echo "Email: {$email} <br />";
+			break;
+		}
 	}
-	else
+	if (!$email)
 	{
 		echo "<p style=\"{$errorStyle}\">Invalid Map Email. If your LDAP server does not use emails, then use a 'fake' email.</p>";
 	}

--- a/administrator/language/en-GB/en-GB.com_shldap.ini
+++ b/administrator/language/en-GB/en-GB.com_shldap.ini
@@ -114,10 +114,10 @@ COM_SHLDAP_HOST_SPACER_MAPPING="Mapping Attributes"
 COM_SHLDAP_HOST_FIELD_UID_DESC="Specify the LDAP attribute that contains the user's ID for mapping to the Joomla login name field.<br /><br />Examples:<ul><li>sAMAccountName <em>(can be used for AD)</em></li><li>uid <em>(used for most LDAP systems)</em></li></ul>"
 COM_SHLDAP_HOST_FIELD_UID_LABEL="Map User ID"
 
-COM_SHLDAP_HOST_FIELD_FULLNAME_DESC="Specify the LDAP attribute that contains the user's full name for mapping to the Joomla name field.<br /><br />Examples:<ul><li>name <em>(can be used for AD)</em></li><li>displayName <em>(can be used for AD)</em></li><li>fullName <em>(used for most LDAP systems)</em></li></ul>"
+COM_SHLDAP_HOST_FIELD_FULLNAME_DESC="Specify the LDAP attribute that contains the user's full name for mapping to the Joomla name field.<br /><br />Examples:<ul><li>name <em>(can be used for AD)</em></li><li>displayName <em>(can be used for AD)</em></li><li>fullName <em>(used for most LDAP systems)</em></li></ul>You can specify multiple attributes separated by comma. In this case, the first one value of the first one attribute will be used."
 COM_SHLDAP_HOST_FIELD_FULLNAME_LABEL="Map Full Name"
 
-COM_SHLDAP_HOST_FIELD_EMAIL_DESC="Specify the LDAP attribute that contains the user's email for mapping to the Joomla email field. The attribute 'mail' is used as a default for most LDAP systems. <br /><br />If the LDAP directory doesn't contain email values, then a 'fake' email can be implemented. These can be implemented by using the [username] keyword which is dynamically replaced by the username. For example <strong>[username]@ACME.LOCAL</strong>."
+COM_SHLDAP_HOST_FIELD_EMAIL_DESC="Specify the LDAP attribute that contains the user's email for mapping to the Joomla email field. The attribute 'mail' is used as a default for most LDAP systems.<br /><br />You can specify multiple attributes separated by comma. In this case, the first one value of the first one attribute will be used.<br /><br />If the LDAP directory doesn't contain email values, then a 'fake' email can be implemented. These can be implemented by using the [username] keyword which is dynamically replaced by the username. For example <strong>[username]@ACME.LOCAL</strong>."
 COM_SHLDAP_HOST_FIELD_EMAIL_LABEL="Map Email"
 
 COM_SHLDAP_HOST_SPACER_PASSWORD="Password Attributes (for password sets only)"

--- a/libraries/shmanic/user/adapter/ldap.php
+++ b/libraries/shmanic/user/adapter/ldap.php
@@ -377,7 +377,7 @@ class SHUserAdapterLdap extends SHUserAdapter
 			}
 
 			// Add both of the uid and fullname to the set of attributes to get.
-			$needToFind[] = $this->client->ldap_fullname;
+			$needToFind = array_merge($needToFind, explode(',',$this->client->ldap_fullname));
 			$needToFind[] = $this->client->ldap_uid;
 
 			// Check for a fake email
@@ -386,7 +386,7 @@ class SHUserAdapterLdap extends SHUserAdapter
 			// Add the email attribute only if not a fake email is supplied.
 			if (!$fakeEmail)
 			{
-				$needToFind[] = $this->client->ldap_email;
+				$needToFind = array_merge($needToFind,explode(',',$this->client->ldap_email));
 			}
 
 			// Re-order array to ensure an LDAP read is successful and no duplicates exist.
@@ -546,18 +546,23 @@ class SHUserAdapterLdap extends SHUserAdapter
 			// Only return the key id
 			$this->getId(false);
 
-			return $this->client->keyName;
+			return explode(',',$this->client->keyName)[0];
 		}
 
-		// Find the Ldap attribute name key
-		$key = $this->client->keyName;
+		// Find the Ldap attribute(s) name key
+		$key_attrs = $this->client->keyName;
 
-		if ($value = $this->getAttributes($key))
+		$keys=explode(',',$key_attrs);
+
+		foreach ($keys as $key)
 		{
-			if (isset($value[$key][0]))
+			if ($value = $this->getAttributes($key))
 			{
-				// Fullname found so lets return it
-				return $value[$key][0];
+				if (isset($value[$key][0]))
+				{
+					// Fullname found so lets return it
+					return $value[$key][0];
+				}
 			}
 		}
 
@@ -581,18 +586,22 @@ class SHUserAdapterLdap extends SHUserAdapter
 			// Only return the key id
 			$this->getId(false);
 
-			return $this->client->keyEmail;
+			return explode(',',$this->client->keyEmail)[0];
 		}
 
-		// Find the Ldap attribute email key
-		$key = $this->client->keyEmail;
+		// Find the Ldap attribute(s) email key
+		$key_attrs = $this->client->keyEmail;
 
-		if ($value = $this->getAttributes($key))
+		$keys=explode(',',$key_attrs);
+		foreach ($keys as $key)
 		{
-			if (isset($value[$key][0]))
+			if ($value = $this->getAttributes($key))
 			{
-				// Email found so lets return it
-				return $value[$key][0];
+				if (isset($value[$key][0]))
+				{
+					// Email found so lets return it
+					return $value[$key][0];
+				}
 			}
 		}
 


### PR DESCRIPTION
Hello,

This pull request permit to add possibility to configure multiple LDAP attributes name for fullname and email mapping. This is usefull to handle difference on LDAP objects schema usage.
For instance, if some people doesn't have _mail_ attribute but have an _mailPerso_ attribute, this feature permit to fetch _mail_ attribute value for the first one population and _mailPerso_ attribute value for the second one.